### PR TITLE
Enable Hackage-friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -33,3 +33,4 @@ extra-package-dbs: []
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+pvp-bounds: both


### PR DESCRIPTION
This helps ensure that the cabal meta-data is more accurate and so that install-plans don't bitrot that easily over time.

See also https://docs.haskellstack.org/en/stable/yaml_configuration/?highlight=pvp-bounds#pvp-bounds